### PR TITLE
allow no outputs in signTx

### DIFF
--- a/src/securityPolicy.h
+++ b/src/securityPolicy.h
@@ -22,7 +22,13 @@ security_policy_t policyForShowDeriveAddress(const addressParams_t* addressParam
 security_policy_t policyForReturnDeriveAddress(const addressParams_t* addressParams);
 
 
-security_policy_t policyForSignTxInit(uint8_t networkId, uint32_t protocolMagic);
+security_policy_t policyForSignTxInit(
+        uint8_t networkId,
+        uint32_t protocolMagic,
+        uint16_t numOutputs,
+        uint16_t numWithdrawals,
+        bool isSigningPoolRegistrationAsOwner
+);
 
 security_policy_t policyForSignTxInput();
 
@@ -66,6 +72,12 @@ security_policy_t policyForSignTxWitness(
 );
 
 security_policy_t policyForSignTxConfirm();
+
+bool is_tx_network_verifiable(
+        uint16_t numOutputs,
+        uint16_t numWithdrawals,
+        bool isSigningPoolRegistrationAsOwner
+);
 
 
 static inline void ENSURE_NOT_DENIED(security_policy_t policy)


### PR DESCRIPTION
No changes in js code are needed --- the validation did not enforce an output to be present. 
(I added a test for this case, see https://github.com/vacuumlabs/ledgerjs-cardano-shelley/pull/16.)

WARNING: a tx without outputs does not include network id / protocol magic, but we do display the values at the initiation of tx signing to the user. It has not been decided yet what exactly to do about it, or whether we should add an additional warning for the case no outputs are present. Until these UI issues are resolved and implemented, this is not finished.
