### PR TITLE
Fix copying of url from view to metadata struct

### DIFF
--- a/src/signTxPoolRegistration.c
+++ b/src/signTxPoolRegistration.c
@@ -720,7 +720,7 @@ static void signTxPoolRegistration_handlePoolMetadataAPDU(uint8_t* wireDataBuffe
 			md->urlSize = view_remainingSize(&view);
 			VALIDATE(md->urlSize <= POOL_METADATA_URL_MAX_LENGTH, ERR_INVALID_DATA);
 			ASSERT(SIZEOF(md->url) >= md->urlSize);
-			os_memmove(md->url, view.ptr, SIZEOF(md->url));
+			os_memmove(md->url, view.ptr, md->urlSize);
 			view_skipBytes(&view, md->urlSize);
 			str_validateTextBuffer(md->url, md->urlSize);
 		}


### PR DESCRIPTION
Motivation: os_memmove() call to copy the url characters from the APDU view to the metadata structure is apparently moving more bytes than the view has, resulting in potentially unauthorized access to the data beyond the APDU view, as the POOL_METADATA_URL_MAX_LENGTH bytes are being transferred while the APDU view has only as many bytes remaining as the url's actual length.

Changes:
* fix the os_memmove() call parameters to transfer only as many bytes as the actual length of the url being transferred

Testing:
* `yarn test-integration` passes
* `yarn test-device` passes