### PR TITLE
more secure memmove for read views

### DIFF
--- a/src/addressUtilsShelley.c
+++ b/src/addressUtilsShelley.c
@@ -484,8 +484,7 @@ void parseAddressParams(const uint8_t *wireDataBuffer, size_t wireDataSize, addr
 	case STAKING_KEY_HASH:
 		VALIDATE(view_remainingSize(&view) >= ADDRESS_KEY_HASH_LENGTH, ERR_INVALID_DATA);
 		STATIC_ASSERT(SIZEOF(params->stakingKeyHash) == ADDRESS_KEY_HASH_LENGTH, "Wrong address key hash length");
-		os_memmove(params->stakingKeyHash, view.ptr, ADDRESS_KEY_HASH_LENGTH);
-		view_skipBytes(&view, ADDRESS_KEY_HASH_LENGTH);
+		view_memmove(params->stakingKeyHash, &view, ADDRESS_KEY_HASH_LENGTH);
 		TRACE("Staking key hash: ");
 		TRACE_BUFFER(params->stakingKeyHash, SIZEOF(params->stakingKeyHash));
 		break;

--- a/src/bufView.h
+++ b/src/bufView.h
@@ -101,6 +101,15 @@ static inline cbor_token_t view_readToken(read_view_t* view)
 	return token;
 }
 
+// moves <length> bytes from the view to the buffer via os_memmove
+// (view.ptr is advanced accordingly)
+static inline void view_memmove(uint8_t* destBuffer, read_view_t* view, size_t length)
+{
+	ASSERT(length <= view_remainingSize(view));
+	os_memmove(destBuffer, view->ptr, length);
+	view_skipBytes(view, length);
+}
+
 // Note(ppershing): these macros expand to two arguments!
 #define VIEW_REMAINING_TO_TUPLE_BUF_SIZE(view) (view)->ptr, view_remainingSize(view)
 #define VIEW_PROCESSED_TO_TUPLE_BUF_SIZE(view) (view)->begin, view_processedSize(view)

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -965,7 +965,7 @@ static void _parseCertificateData(uint8_t* wireDataBuffer, size_t wireDataSize, 
 	case CERTIFICATE_TYPE_STAKE_DELEGATION: {
 		VALIDATE(view_remainingSize(&view) == POOL_KEY_HASH_LENGTH, ERR_INVALID_DATA);
 		STATIC_ASSERT(SIZEOF(certificateData->poolKeyHash) == POOL_KEY_HASH_LENGTH, "wrong poolKeyHash size");
-		os_memmove(certificateData->poolKeyHash, view.ptr, POOL_KEY_HASH_LENGTH);
+		view_memmove(certificateData->poolKeyHash, &view, POOL_KEY_HASH_LENGTH);
 		break;
 	}
 	default:

--- a/src/signTxPoolRegistration.c
+++ b/src/signTxPoolRegistration.c
@@ -473,8 +473,7 @@ static void signTxPoolRegistration_handleRelayAPDU(uint8_t* wireDataBuffer, size
 				if (includeIpv4 == RELAY_YES) {
 					VALIDATE(view_remainingSize(&view) >= IPV4_SIZE, ERR_INVALID_DATA);
 					STATIC_ASSERT(sizeof(ipv4.ip) == IPV4_SIZE, "wrong ipv4 size"); // SIZEOF does not work for 4-byte buffers
-					os_memmove(ipv4.ip, view.ptr, IPV4_SIZE);
-					view_skipBytes(&view, IPV4_SIZE);
+					view_memmove(ipv4.ip, &view, IPV4_SIZE);
 					TRACE("ipv4");
 					TRACE_BUFFER(ipv4.ip, IPV4_SIZE);
 					ipv4Ptr = &ipv4;
@@ -490,9 +489,8 @@ static void signTxPoolRegistration_handleRelayAPDU(uint8_t* wireDataBuffer, size
 				uint8_t includeIpv6 = parse_u1be(&view);
 				if (includeIpv6 == RELAY_YES) {
 					VALIDATE(view_remainingSize(&view) >= IPV6_SIZE, ERR_INVALID_DATA);
-					STATIC_ASSERT(sizeof(ipv6.ip) == IPV6_SIZE, "wrong ipv6 size"); // SIZEOF does not work for 4-byte buffers
-					os_memmove(ipv6.ip, view.ptr, IPV6_SIZE);
-					view_skipBytes(&view, IPV6_SIZE);
+					STATIC_ASSERT(SIZEOF(ipv6.ip) == IPV6_SIZE, "wrong ipv6 size");
+					view_memmove(ipv6.ip, &view, IPV6_SIZE);
 					TRACE("ipv6");
 					TRACE_BUFFER(ipv6.ip, IPV6_SIZE);
 					ipv6Ptr = &ipv6;
@@ -713,15 +711,13 @@ static void signTxPoolRegistration_handlePoolMetadataAPDU(uint8_t* wireDataBuffe
 		{
 			VALIDATE(view_remainingSize(&view) >= METADATA_HASH_LENGTH, ERR_INVALID_DATA);
 			ASSERT(SIZEOF(md->hash) == METADATA_HASH_LENGTH);
-			os_memmove(md->hash, view.ptr, SIZEOF(md->hash));
-			view_skipBytes(&view, METADATA_HASH_LENGTH);
+			view_memmove(md->hash, &view, METADATA_HASH_LENGTH);
 		}
 		{
 			md->urlSize = view_remainingSize(&view);
 			VALIDATE(md->urlSize <= POOL_METADATA_URL_MAX_LENGTH, ERR_INVALID_DATA);
 			ASSERT(SIZEOF(md->url) >= md->urlSize);
-			os_memmove(md->url, view.ptr, md->urlSize);
-			view_skipBytes(&view, md->urlSize);
+			view_memmove(md->url, &view, md->urlSize);
 			str_validateTextBuffer(md->url, md->urlSize);
 		}
 


### PR DESCRIPTION
Useful to accidentally avoid reading more than a view contains (which os_memmove does not check).