### PR TITLE
Draft: Unify account numbering with Trezor

### DIFF
--- a/src/uiScreens.c
+++ b/src/uiScreens.c
@@ -44,12 +44,12 @@ void ui_displayAccountScreen(
 		if (bip44_hasByronPrefix(path)) {
 			snprintf(
 			        accountDescription, SIZEOF(accountDescription),
-			        "Byron account %u  ", account
+			        "Byron account #%u  ", account + 1
 			);
 		} else if (bip44_hasShelleyPrefix(path)) {
 			snprintf(
 			        accountDescription, SIZEOF(accountDescription),
-			        "Account %u  ", account
+			        "Account #%u  ", account + 1
 			);
 		} else {
 			ASSERT(false);


### PR DESCRIPTION
Motivation: Trezor's account ordinal number displayed to the users is indexed from 1. However, on Ledger, the account number is indexed from 0. This PR is just a draft, final solution TBD

Change:
Key export before:
```
Export public key
Account 0 m/1852'/1815'/0'
```
Key export after:
```
Export public key
Account #1 m/1852'/1815'/0'
```
Testing:
* tested manually with https://adalite.io by logging in with updated Ledger Cardano app

Note: TBD2 - we may want to display the account number also in stake key registration/deregistration/delegation certificates, currently we still display only the BIP32 path