### PR TITLE
WIP: Firmware update 2.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,30 +14,32 @@ Builds and loads the application into connected device. Just make sure to close 
 
 ### Debug version
 
-Uncomment `#DEFINE+=DEVEL` and `#DEFINE+=HEADLESS` in Makefile. Then `make clean load`
+In `Makefile`, uncomment
+
+    #DEFINE+=DEVEL
+    #DEFINE+=HEADLESS
+
+also comment out
+
+    DEFINES += RESET_ON_CRASH
+
+and then run `make clean load`.
 
 ### Setup
 
-Make sure your:
-- SDK >= 1.5.2
-- MCU >= 1.6
+Make sure you have:
+- SDK >= 2.0.0
+- MCU >= 1.11
 
-Environment setup and developer documentation is sufficiently provided in Ledger’s [Read the Docs](http://ledger.readthedocs.io/en/latest/). 
+Environment setup and developer documentation is sufficiently provided in Ledger’s [Read the Docs](https://ledger.readthedocs.io/en/latest/userspace/debugging.html).
+
+You want a debug version of the MCU (but it blocks firmware updates, so for the purpose of upgrading firmware, replace it temporarily with a non-debug one).
 
 ### Setting udev rules
 
-In some Linux distros (e.g. Ubuntu), you might need to setup udev rules before your device can communicate with the system.
-
-On Ubuntu, create a file under `/etc/udev/rules.d` called `01-ledger.rules` and paste this content inside: 
-
-```
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0000", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="__user__"
-SUBSYSTEMS=="usb", ATTRS{idVendor}=="2c97", ATTRS{idProduct}=="0001", MODE="0660", TAG+="uaccess", TAG+="udev-acl" OWNER="__user__"
-```
-
-replacing `__user__` with your system's user name.
-
-Run `udevadm control --reload` in system's shell to load the changes.
+You might need to setup udev rules before your device can communicate with the system.
+- https://ledger.readthedocs.io/en/latest/userspace/setup.html
+- https://support.ledger.com/hc/en-us/articles/115005165269-Fix-connection-issues
 
 ## Development
 
@@ -49,11 +51,10 @@ The build process is managed with [Make](https://www.gnu.org/software/make/).
 
 ### Make Commands
 
+* `load`: Load signed app onto the Ledger device
 * `clean`: Clean the build and output directories
 * `delete`: Remove the application from the device
-* `load`: Load signed app onto the Ledger device
 * `build`: Build obj and bin api artefacts without loading
-* `sign`: Sign current app.hex with CA private key
-* `deploy`: Load the current app.hex onto the Ledger device
+* `format`: Format source code.
 
 See `Makefile` for list of included functions.

--- a/src/addressUtilsByron_test.c
+++ b/src/addressUtilsByron_test.c
@@ -10,7 +10,7 @@
 static void pathSpec_init(bip44_path_t* pathSpec, const uint32_t* pathArray, uint32_t pathLength)
 {
 	pathSpec->length = pathLength;
-	os_memmove(pathSpec->path, pathArray, pathLength * 4);
+	memmove(pathSpec->path, pathArray, pathLength * 4);
 }
 
 void testcase_deriveAddress_byron(uint32_t* path, uint32_t pathLen, uint32_t protocolMagic, const char* expectedHex)

--- a/src/addressUtilsShelley_test.c
+++ b/src/addressUtilsShelley_test.c
@@ -12,7 +12,7 @@
 static void pathSpec_init(bip44_path_t* pathSpec, const uint32_t* pathArray, uint32_t pathLength)
 {
 	pathSpec->length = pathLength;
-	os_memmove(pathSpec->path, pathArray, pathLength * 4);
+	memmove(pathSpec->path, pathArray, pathLength * 4);
 }
 
 // networkIdOrProtocolMagic is used as networkId for Shelley addresses and as protocol magic for Byron addresses

--- a/src/base58.c
+++ b/src/base58.c
@@ -37,7 +37,7 @@ size_t base58_encode(
 	ASSERT(inSize <= SIZEOF(tmpBuffer));
 	ASSERT(outMaxSize < BUFFER_SIZE_PARANOIA);
 
-	os_memmove(tmpBuffer, inBuffer, inSize);
+	memmove(tmpBuffer, inBuffer, inSize);
 
 	while ((zeroCount < inSize) && (tmpBuffer[zeroCount] == 0)) {
 		++zeroCount;
@@ -71,7 +71,7 @@ size_t base58_encode(
 
 	ASSERT(outSize < outMaxSize);
 
-	os_memmove(outStr, (buffer + j), outSize);
+	memmove(outStr, (buffer + j), outSize);
 	outStr[outSize] = 0;
 	return outSize;
 }

--- a/src/bip44_test.c
+++ b/src/bip44_test.c
@@ -9,7 +9,7 @@
 static void pathSpec_init(bip44_path_t* pathSpec, const uint32_t* pathArray, uint32_t pathLength)
 {
 	pathSpec->length = pathLength;
-	os_memmove(pathSpec->path, pathArray, pathLength * 4);
+	memmove(pathSpec->path, pathArray, pathLength * 4);
 }
 
 void testcase_printToStr(const uint32_t* path, uint32_t pathLen, size_t outputSize, const char* expected)

--- a/src/bufView.h
+++ b/src/bufView.h
@@ -89,7 +89,7 @@ static inline void view_appendData(write_view_t* view, const uint8_t* dataBuffer
 {
 	view_check(view);
 	VALIDATE(dataSize <= view_remainingSize(view), ERR_DATA_TOO_LARGE);
-	os_memcpy(view->ptr, dataBuffer, dataSize);
+	memcpy(view->ptr, dataBuffer, dataSize);
 	view->ptr += dataSize;
 	view_check(view);
 }
@@ -101,12 +101,12 @@ static inline cbor_token_t view_readToken(read_view_t* view)
 	return token;
 }
 
-// moves <length> bytes from the view to the buffer via os_memmove
+// moves <length> bytes from the view to the buffer via memmove
 // (view.ptr is advanced accordingly)
 static inline void view_memmove(uint8_t* destBuffer, read_view_t* view, size_t length)
 {
 	ASSERT(length <= view_remainingSize(view));
-	os_memmove(destBuffer, view->ptr, length);
+	memmove(destBuffer, view->ptr, length);
 	view_skipBytes(view, length);
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -62,7 +62,7 @@ void io_send_buf(uint16_t code, uint8_t* buffer, size_t bufferSize)
 {
 	CHECK_RESPONSE_SIZE(bufferSize);
 
-	os_memmove(G_io_apdu_buffer, buffer, bufferSize);
+	memmove(G_io_apdu_buffer, buffer, bufferSize);
 	_io_send_G_io_apdu_buffer(code, bufferSize);
 }
 

--- a/src/keyDerivation.c
+++ b/src/keyDerivation.c
@@ -47,7 +47,7 @@ void derivePrivateKey(
 			// should work with the new SDK
 			privateKey->curve = CX_CURVE_Ed25519;
 			privateKey->d_len = 64;
-			os_memmove(privateKey->d, privateKeyRawBuffer, 64);
+			memmove(privateKey->d, privateKeyRawBuffer, 64);
 		}
 		FINALLY {
 			explicit_bzero(privateKeyRawBuffer, SIZEOF(privateKeyRawBuffer));
@@ -125,7 +125,7 @@ void deriveExtendedPublicKey(
 			// Chain code (we copy it second to avoid mid-updates extractRawPublicKey throws
 			STATIC_ASSERT(CHAIN_CODE_SIZE == SIZEOF(out->chainCode), "bad chain code size");
 			STATIC_ASSERT(CHAIN_CODE_SIZE == SIZEOF(chainCode.code), "bad chain code size");
-			os_memmove(out->chainCode, chainCode.code, CHAIN_CODE_SIZE);
+			memmove(out->chainCode, chainCode.code, CHAIN_CODE_SIZE);
 		}
 		FINALLY {
 			explicit_bzero(&privateKey, SIZEOF(privateKey));

--- a/src/keyDerivation_test.c
+++ b/src/keyDerivation_test.c
@@ -7,7 +7,7 @@
 static void pathSpec_init(bip44_path_t* pathSpec, const uint32_t* pathArray, uint32_t pathLength)
 {
 	pathSpec->length = pathLength;
-	os_memmove(pathSpec->path, pathArray, pathLength * 4);
+	memmove(pathSpec->path, pathArray, pathLength * 4);
 }
 
 void testcase_derivePrivateKey(uint32_t* path, uint32_t pathLen, const char* expectedHex)

--- a/src/messageSigning.c
+++ b/src/messageSigning.c
@@ -27,7 +27,7 @@ static void signRawMessage(privateKey_t* privateKey,
 	io_seproxyhal_io_heartbeat();
 
 	ASSERT(signatureSize == ED25519_SIGNATURE_LENGTH);
-	os_memmove(outBuffer, signature, signatureSize);
+	memmove(outBuffer, signature, signatureSize);
 }
 
 static void signRawMessageWithPath(bip44_path_t* pathSpec,

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -284,7 +284,7 @@ static inline void checkForFinishedSubmachines()
 
 			STATIC_ASSERT(SIZEOF(ctx->auxDataHash) == AUX_DATA_HASH_LENGTH, "Wrong auxiliary data hash length");
 			STATIC_ASSERT(SIZEOF(txAuxDataCtx->stageContext.catalyst_registration_subctx.auxDataHash) == AUX_DATA_HASH_LENGTH, "Wrong auxiliary data hash length");
-			os_memmove(ctx->auxDataHash, txAuxDataCtx->stageContext.catalyst_registration_subctx.auxDataHash, AUX_DATA_HASH_LENGTH);
+			memmove(ctx->auxDataHash, txAuxDataCtx->stageContext.catalyst_registration_subctx.auxDataHash, AUX_DATA_HASH_LENGTH);
 
 			advanceStage();
 		}
@@ -694,7 +694,7 @@ static void signTx_handleInputAPDU(uint8_t p2, uint8_t* wireDataBuffer, size_t w
 
 		VALIDATE(wireDataSize == SIZEOF(*wireUtxo), ERR_INVALID_DATA);
 
-		os_memmove(input.txHashBuffer, wireUtxo->txHash, SIZEOF(input.txHashBuffer));
+		memmove(input.txHashBuffer, wireUtxo->txHash, SIZEOF(input.txHashBuffer));
 		input.parsedIndex =  u4be_read(wireUtxo->index);
 	}
 

--- a/src/signTxCatalystRegistration.c
+++ b/src/signTxCatalystRegistration.c
@@ -496,10 +496,10 @@ static void signTxCatalystRegistration_handleConfirm_ui_runStep()
 		} wireResponse;
 
 		STATIC_ASSERT(SIZEOF(subctx->auxDataHash) == AUX_DATA_HASH_LENGTH, "Wrong aux data hash length");
-		os_memmove(wireResponse.auxDataHash, subctx->auxDataHash, AUX_DATA_HASH_LENGTH);
+		memmove(wireResponse.auxDataHash, subctx->auxDataHash, AUX_DATA_HASH_LENGTH);
 
 		STATIC_ASSERT(SIZEOF(subctx->stateData.registrationSignature) == ED25519_SIGNATURE_LENGTH, "Wrong Catalyst registration signature length");
-		os_memmove(wireResponse.signature, subctx->stateData.registrationSignature, ED25519_SIGNATURE_LENGTH);
+		memmove(wireResponse.signature, subctx->stateData.registrationSignature, ED25519_SIGNATURE_LENGTH);
 
 		io_send_buf(SUCCESS, (uint8_t*) &wireResponse, SIZEOF(wireResponse));
 		advanceState();

--- a/src/signTxPoolRegistration.c
+++ b/src/signTxPoolRegistration.c
@@ -212,12 +212,12 @@ static void signTxPoolRegistration_handlePoolParamsAPDU(uint8_t* wireDataBuffer,
 
 			TRACE_BUFFER(wireHeader->poolKeyHash, SIZEOF(wireHeader->poolKeyHash));
 			STATIC_ASSERT(SIZEOF(wireHeader->poolKeyHash) == SIZEOF(p->poolKeyHash), "wrong poolKeyHash size");
-			os_memmove(p->poolKeyHash, wireHeader->poolKeyHash, SIZEOF(p->poolKeyHash));
+			memmove(p->poolKeyHash, wireHeader->poolKeyHash, SIZEOF(p->poolKeyHash));
 			// nothing to validate, all values are valid
 
 			TRACE_BUFFER(wireHeader->vrfKeyHash, SIZEOF(wireHeader->vrfKeyHash));
 			STATIC_ASSERT(SIZEOF(wireHeader->vrfKeyHash) == SIZEOF(p->vrfKeyHash), "wrong vrfKeyHash size");
-			os_memmove(p->vrfKeyHash, wireHeader->vrfKeyHash, SIZEOF(p->vrfKeyHash));
+			memmove(p->vrfKeyHash, wireHeader->vrfKeyHash, SIZEOF(p->vrfKeyHash));
 			// nothing to validate, all values are valid
 
 			ASSERT_TYPE(p->pledge, uint64_t);
@@ -244,7 +244,7 @@ static void signTxPoolRegistration_handlePoolParamsAPDU(uint8_t* wireDataBuffer,
 
 			TRACE_BUFFER(wireHeader->rewardAccount, SIZEOF(wireHeader->rewardAccount));
 			STATIC_ASSERT(SIZEOF(wireHeader->rewardAccount) == SIZEOF(p->rewardAccount), "wrong reward account size");
-			os_memmove(p->rewardAccount, wireHeader->rewardAccount, SIZEOF(p->rewardAccount));
+			memmove(p->rewardAccount, wireHeader->rewardAccount, SIZEOF(p->rewardAccount));
 			const uint8_t header = getAddressHeader(p->rewardAccount, SIZEOF(p->rewardAccount));
 			VALIDATE(getAddressType(header) == REWARD, ERR_INVALID_DATA);
 			VALIDATE(getNetworkId(header) == commonTxData->networkId, ERR_INVALID_DATA);
@@ -346,7 +346,7 @@ static void signTxPoolRegistration_handleOwnerAPDU(uint8_t* wireDataBuffer, size
 		case SIGN_TX_POOL_OWNER_TYPE_KEY_HASH:
 			VALIDATE(view_remainingSize(&view) == ADDRESS_KEY_HASH_LENGTH, ERR_INVALID_DATA);
 			STATIC_ASSERT(SIZEOF(subctx->owner.keyHash) == ADDRESS_KEY_HASH_LENGTH, "wrong owner.keyHash size");
-			os_memmove(subctx->owner.keyHash, VIEW_REMAINING_TO_TUPLE_BUF_SIZE(&view));
+			memmove(subctx->owner.keyHash, VIEW_REMAINING_TO_TUPLE_BUF_SIZE(&view));
 			TRACE_BUFFER(subctx->owner.keyHash, SIZEOF(subctx->owner.keyHash));
 			break;
 
@@ -618,7 +618,7 @@ static void handleMetadata_ui_runStep()
 	UI_STEP(HANDLE_METADATA_STEP_DISPLAY_URL) {
 		char metadataUrlStr[1 + POOL_METADATA_URL_MAX_LENGTH];
 		ASSERT(md->urlSize <= POOL_METADATA_URL_MAX_LENGTH);
-		os_memcpy(metadataUrlStr, md->url, md->urlSize);
+		memcpy(metadataUrlStr, md->url, md->urlSize);
 		metadataUrlStr[md->urlSize] = '\0';
 		ASSERT(strlen(metadataUrlStr) == md->urlSize);
 

--- a/src/testUtils.h
+++ b/src/testUtils.h
@@ -28,7 +28,7 @@
 #define EXPECT_EQ(expr, result) ASSERT(expr == result)
 
 // Assert that first len bytes are same
-#define EXPECT_EQ_BYTES(ptr1, ptr2, size) ASSERT(os_memcmp(ptr1, ptr2, size) == 0);
+#define EXPECT_EQ_BYTES(ptr1, ptr2, size) ASSERT(memcmp(ptr1, ptr2, size) == 0);
 
 // Assert that streams have have available content
 #define EXPECT_EQ_STREAM(s1_ptr, s2_ptr) \

--- a/src/textUtils_test.c
+++ b/src/textUtils_test.c
@@ -31,7 +31,7 @@ void test_formatAda()
 	{
 		PRINTF("test_formatAda edge cases");
 		char tmp[16];
-		os_memset(tmp, 'X', SIZEOF(tmp));
+		memset(tmp, 'X', SIZEOF(tmp));
 		str_formatAdaAmount(0, tmp, 13);
 		EXPECT_EQ(tmp[12], 0);
 		EXPECT_EQ(tmp[13], 'X');

--- a/src/uiHelpers.c
+++ b/src/uiHelpers.c
@@ -152,8 +152,8 @@ void ui_displayPrompt(
 	promptState_t* ctx = promptState;
 
 	// Copy data
-	os_memmove(ctx->header, headerStr, header_len + 1);
-	os_memmove(ctx->text, bodyStr, text_len + 1);
+	memmove(ctx->header, headerStr, header_len + 1);
+	memmove(ctx->text, bodyStr, text_len + 1);
 
 	uiCallback_init(&ctx->callback, confirm, reject);
 	ctx->initMagic = INIT_MAGIC_PROMPT;
@@ -189,12 +189,12 @@ void ui_displayPaginatedText(
 	explicit_bzero(ctx, SIZEOF(*ctx));
 
 	// Copy data
-	os_memmove(ctx->header, headerStr, header_len);
-	os_memmove(ctx->fullText, bodyStr, body_len);
+	memmove(ctx->header, headerStr, header_len);
+	memmove(ctx->fullText, bodyStr, body_len);
 
 	ctx->scrollIndex = 0;
 
-	os_memmove(
+	memmove(
 	        ctx->currentText,
 	        ctx->fullText,
 	        SIZEOF(ctx->currentText) - 1

--- a/src/uiHelpers_nanos.c
+++ b/src/uiHelpers_nanos.c
@@ -46,7 +46,7 @@ static void scroll_update_display_content()
 	assert_uiPaginatedText_magic();
 	ASSERT(ctx->currentText[SIZEOF(ctx->currentText) - 1] == '\0');
 	ASSERT(ctx->scrollIndex + SIZEOF(ctx->currentText) <= SIZEOF(ctx->fullText));
-	os_memmove(
+	memmove(
 	        ctx->currentText,
 	        ctx->fullText + ctx->scrollIndex,
 	        SIZEOF(ctx->currentText) - 1


### PR DESCRIPTION
Replace functions deprecated in Ledger firmware 2.0.0.
Improve `Makefile` (remove unused definitions, improve formatting target, some reorganization).
Improve `README.md`.

Not finished, waiting to try it when 2.0.0 becomes available.