### PR TITLE
remove bech32prefix TODO

### DIFF
--- a/src/addressUtilsByron.c
+++ b/src/addressUtilsByron.c
@@ -23,7 +23,7 @@ void addressRootFromExtPubKey(
         uint8_t* outBuffer, size_t outSize
 )
 {
-	ASSERT(SIZEOF(*extPubKey) == EXTENDED_PUBKEY_SIZE);
+	STATIC_ASSERT(SIZEOF(*extPubKey) == EXTENDED_PUBKEY_SIZE, "wrong ext pub key size");
 	ASSERT(outSize == ADDRESS_ROOT_SIZE);
 
 	uint8_t cborBuffer[64 + 10];

--- a/src/addressUtilsShelley.c
+++ b/src/addressUtilsShelley.c
@@ -525,18 +525,15 @@ static void readHashToBufferFromView(uint8_t* buffer, size_t bufferSize, read_vi
 void view_parseAddressParams(read_view_t* view, addressParams_t* params)
 {
 	// address type
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	params->type = parse_u1be(view);
 	TRACE("Address type: 0x%x", params->type);
 	VALIDATE(isSupportedAddressType(params->type), ERR_UNSUPPORTED_ADDRESS_TYPE);
 
 	// protocol magic / network id
 	if (params->type == BYRON) {
-		VALIDATE(view_remainingSize(view) >= 4, ERR_INVALID_DATA);
 		params->protocolMagic = parse_u4be(view);
 		TRACE("Protocol magic: 0x%x", params->protocolMagic);
 	} else {
-		VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 		params->networkId = parse_u1be(view);
 		TRACE("Network id: 0x%x", params->networkId);
 		VALIDATE(isValidNetworkId(params->networkId), ERR_INVALID_DATA);
@@ -574,7 +571,6 @@ void view_parseAddressParams(read_view_t* view, addressParams_t* params)
 	}
 
 	// staking choice
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	params->stakingDataSource = parse_u1be(view);
 	TRACE("Staking choice: 0x%x", (unsigned int) params->stakingDataSource);
 	VALIDATE(isValidStakingChoice(params->stakingDataSource), ERR_INVALID_DATA);
@@ -604,7 +600,6 @@ void view_parseAddressParams(read_view_t* view, addressParams_t* params)
 	}
 
 	case BLOCKCHAIN_POINTER:
-		VALIDATE(view_remainingSize(view) >= 12, ERR_INVALID_DATA);
 		params->stakingKeyBlockchainPointer.blockIndex = parse_u4be(view);
 		params->stakingKeyBlockchainPointer.txIndex = parse_u4be(view);
 		params->stakingKeyBlockchainPointer.certificateIndex = parse_u4be(view);

--- a/src/bufView.h
+++ b/src/bufView.h
@@ -120,8 +120,9 @@ typedef uint32_t uint_width4_t;
 typedef uint64_t uint_width8_t;
 
 #define __DEFINE_VIEW_parse_ube(width) \
+	/* assumes we are reading from wire, so ERR_INVALID_DATA is thrown if not enough data*/ \
 	static inline uint_width##width##_t parse_u##width##be(read_view_t* view) { \
-		VALIDATE(view_remainingSize(view) >= width, ERR_NOT_ENOUGH_INPUT); \
+		VALIDATE(view_remainingSize(view) >= width, ERR_INVALID_DATA); \
 		uint_width##width##_t result = u##width##be_read(view->ptr); \
 		view->ptr += width; \
 		return result; \

--- a/src/bufView.h
+++ b/src/bufView.h
@@ -101,11 +101,11 @@ static inline cbor_token_t view_readToken(read_view_t* view)
 	return token;
 }
 
-// moves <length> bytes from the view to the buffer via memmove
-// (view.ptr is advanced accordingly)
-static inline void view_memmove(uint8_t* destBuffer, read_view_t* view, size_t length)
+// copies <length> bytes from the view to the buffer
+// throws ERR_INVALID_DATA if not enough data
+static inline void view_copyWireToBuffer(uint8_t* destBuffer, read_view_t* view, size_t length)
 {
-	ASSERT(length <= view_remainingSize(view));
+	VALIDATE(view_remainingSize(view) >= length, ERR_INVALID_DATA);
 	memmove(destBuffer, view->ptr, length);
 	view_skipBytes(view, length);
 }

--- a/src/cardano.c
+++ b/src/cardano.c
@@ -11,7 +11,7 @@ void rewardAccountToBuffer(
 	switch (rewardAccount->keyReferenceType) {
 
 	case KEY_REFERENCE_HASH: {
-		ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE);
+		STATIC_ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account hash buffer size");
 		memmove(rewardAccountBuffer, rewardAccount->hashBuffer, REWARD_ACCOUNT_SIZE);
 		break;
 	}

--- a/src/cardano.c
+++ b/src/cardano.c
@@ -11,7 +11,7 @@ void rewardAccountToBuffer(
 	switch (rewardAccount->keyReferenceType) {
 
 	case KEY_REFERENCE_HASH: {
-		STATIC_ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account size");
+		ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE);
 		memmove(rewardAccountBuffer, rewardAccount->hashBuffer, REWARD_ACCOUNT_SIZE);
 		break;
 	}

--- a/src/deriveNativeScriptHash.c
+++ b/src/deriveNativeScriptHash.c
@@ -235,7 +235,7 @@ static void deriveNativeScriptHash_handleNofK(read_view_t* view)
 	// parse data
 	ctx->scriptContent.requiredScripts = parse_u4be(view);
 	TRACE_WITH_CTX("required scripts = %u, ", ctx->scriptContent.requiredScripts);
-	
+
 	VALIDATE(view_remainingSize(view) == 0, ERR_INVALID_DATA);
 
 	// validate that the received requiredScripts count makes sense
@@ -297,10 +297,11 @@ static void deriveNativeScriptHash_handleDeviceOwnedPubkey(read_view_t* view)
 
 static void deriveNativeScriptHash_handleThirdPartyPubkey(read_view_t* view)
 {
-	VALIDATE(view_remainingSize(view) == ADDRESS_KEY_HASH_LENGTH, ERR_INVALID_DATA);
 	STATIC_ASSERT(SIZEOF(ctx->scriptContent.pubkeyHash) == ADDRESS_KEY_HASH_LENGTH, "incorrect key hash size in script");
-	view_memmove(ctx->scriptContent.pubkeyHash, view, ADDRESS_KEY_HASH_LENGTH);
+	view_copyWireToBuffer(ctx->scriptContent.pubkeyHash, view, ADDRESS_KEY_HASH_LENGTH);
 	TRACE_BUFFER(ctx->scriptContent.pubkeyHash, ADDRESS_KEY_HASH_LENGTH);
+
+	VALIDATE(view_remainingSize(view) == 0, ERR_INVALID_DATA);
 
 	nativeScriptHashBuilder_addScript_pubkey(&ctx->hashBuilder, ctx->scriptContent.pubkeyHash, SIZEOF(ctx->scriptContent.pubkeyHash));
 

--- a/src/getPublicKeys.c
+++ b/src/getPublicKeys.c
@@ -210,12 +210,14 @@ static void getPublicKeys_handleInitAPDU(uint8_t* wireDataBuffer, size_t wireDat
 		case 4: {
 			// read the number of remaining paths
 			uint32_t remainingPaths = parse_u4be(&view);
-			ASSERT(view_remainingSize(&view) == 0);
 			VALIDATE(remainingPaths < MAX_PUBLIC_KEYS, ERR_INVALID_DATA);
 			ASSERT_TYPE(ctx->numPaths, uint16_t);
 			ASSERT(remainingPaths < UINT16_MAX);
 
 			ctx->numPaths = (uint16_t) (remainingPaths + 1);
+
+			VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
+
 			break;
 		}
 		default: {

--- a/src/signOpCert.c
+++ b/src/signOpCert.c
@@ -58,19 +58,17 @@ void signOpCert_handleAPDU(
 		TRACE("KES key:");
 		TRACE_BUFFER(ctx->kesPublicKey, KES_PUBLIC_KEY_LENGTH);
 
-		VALIDATE(view_remainingSize(&view) >= 8, ERR_INVALID_DATA);
 		ctx->kesPeriod = parse_u8be(&view);
 		TRACE("KES period:");
 		TRACE_UINT64(ctx->kesPeriod);
 
-		VALIDATE(view_remainingSize(&view) >= 8, ERR_INVALID_DATA);
 		ctx->issueCounter = parse_u8be(&view);
 		TRACE("Issue counter:");
 		TRACE_UINT64(ctx->issueCounter);
 
 		view_skipBytes(&view, bip44_parseFromWire(&ctx->poolColdKeyPathSpec, VIEW_REMAINING_TO_TUPLE_BUF_SIZE(&view)));
 
-		ASSERT(view_remainingSize(&view) == 0);
+		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 	}
 
 	// Check security policy

--- a/src/signOpCert.c
+++ b/src/signOpCert.c
@@ -53,8 +53,7 @@ void signOpCert_handleAPDU(
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
 		STATIC_ASSERT(SIZEOF(ctx->kesPublicKey) == KES_PUBLIC_KEY_LENGTH, "wrong KES public key size");
-		VALIDATE(view_remainingSize(&view) >= KES_PUBLIC_KEY_LENGTH, ERR_INVALID_DATA);
-		view_memmove(ctx->kesPublicKey, &view, KES_PUBLIC_KEY_LENGTH);
+		view_copyWireToBuffer(ctx->kesPublicKey, &view, KES_PUBLIC_KEY_LENGTH);
 		TRACE("KES key:");
 		TRACE_BUFFER(ctx->kesPublicKey, KES_PUBLIC_KEY_LENGTH);
 

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -615,9 +615,8 @@ static void signTx_handleAuxDataAPDU(uint8_t p2, uint8_t* wireDataBuffer, size_t
 
 		case AUX_DATA_TYPE_ARBITRARY_HASH: {
 			// parse data
-			VALIDATE(view_remainingSize(&view) == AUX_DATA_HASH_LENGTH, ERR_INVALID_DATA);
 			STATIC_ASSERT(SIZEOF(ctx->auxDataHash) == AUX_DATA_HASH_LENGTH, "wrong auxiliary data hash length");
-			view_memmove(ctx->auxDataHash, &view, AUX_DATA_HASH_LENGTH);
+			view_copyWireToBuffer(ctx->auxDataHash, &view, AUX_DATA_HASH_LENGTH);
 			txAuxDataCtx->auxDataReceived = true;
 			break;
 		}
@@ -1107,8 +1106,7 @@ static void _parseStakeCredential(read_view_t* view, stake_credential_t* stakeCr
 		break;
 	case STAKE_CREDENTIAL_SCRIPT_HASH: {
 		STATIC_ASSERT(SIZEOF(stakeCredential->scriptHash) == SCRIPT_HASH_LENGTH, "bad script hash container size");
-		VALIDATE(view_remainingSize(view) >= SIZEOF(stakeCredential->scriptHash), ERR_INVALID_DATA);
-		view_memmove(stakeCredential->scriptHash, view, SIZEOF(stakeCredential->scriptHash));
+		view_copyWireToBuffer(stakeCredential->scriptHash, view, SIZEOF(stakeCredential->scriptHash));
 		break;
 	}
 
@@ -1138,9 +1136,8 @@ static void _parseCertificateData(uint8_t* wireDataBuffer, size_t wireDataSize, 
 
 	case CERTIFICATE_TYPE_STAKE_DELEGATION:
 		_parseStakeCredential(&view, &certificateData->stakeCredential);
-		VALIDATE(view_remainingSize(&view) == POOL_KEY_HASH_LENGTH, ERR_INVALID_DATA);
 		STATIC_ASSERT(SIZEOF(certificateData->poolKeyHash) == POOL_KEY_HASH_LENGTH, "wrong poolKeyHash size");
-		view_memmove(certificateData->poolKeyHash, &view, POOL_KEY_HASH_LENGTH);
+		view_copyWireToBuffer(certificateData->poolKeyHash, &view, POOL_KEY_HASH_LENGTH);
 		break;
 
 	case CERTIFICATE_TYPE_STAKE_POOL_REGISTRATION:

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -609,24 +609,27 @@ static void signTx_handleAuxDataAPDU(uint8_t p2, uint8_t* wireDataBuffer, size_t
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
-		VALIDATE(view_remainingSize(&view) >= 1, ERR_INVALID_DATA);
-		txAuxDataCtx->auxDataType = parse_u1be(&view);
 
+		txAuxDataCtx->auxDataType = parse_u1be(&view);
 		switch (txAuxDataCtx->auxDataType) {
-		case AUX_DATA_TYPE_ARBITRARY_HASH:
+
+		case AUX_DATA_TYPE_ARBITRARY_HASH: {
 			// parse data
 			VALIDATE(view_remainingSize(&view) == AUX_DATA_HASH_LENGTH, ERR_INVALID_DATA);
 			STATIC_ASSERT(SIZEOF(ctx->auxDataHash) == AUX_DATA_HASH_LENGTH, "wrong auxiliary data hash length");
 			view_memmove(ctx->auxDataHash, &view, AUX_DATA_HASH_LENGTH);
 			txAuxDataCtx->auxDataReceived = true;
 			break;
+		}
+
 		case AUX_DATA_TYPE_CATALYST_REGISTRATION:
 			break;
+
 		default:
 			THROW(ERR_INVALID_DATA);
 		}
 
-		ASSERT(view_remainingSize(&view) == 0);
+		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 	}
 
 
@@ -725,7 +728,7 @@ static void signTx_handleInputAPDU(uint8_t p2, uint8_t* wireDataBuffer, size_t w
 		VALIDATE(wireDataSize == SIZEOF(*wireUtxo), ERR_INVALID_DATA);
 
 		memmove(input.txHashBuffer, wireUtxo->txHash, SIZEOF(input.txHashBuffer));
-		input.parsedIndex =  u4be_read(wireUtxo->index);
+		input.parsedIndex = u4be_read(wireUtxo->index);
 	}
 
 	{
@@ -1097,7 +1100,6 @@ static void _parsePathSpec(read_view_t* view, bip44_path_t* pathSpec)
 
 static void _parseStakeCredential(read_view_t* view, stake_credential_t* stakeCredential)
 {
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	stakeCredential->type = parse_u1be(view);
 	switch (stakeCredential->type) {
 	case STAKE_CREDENTIAL_KEY_PATH:
@@ -1105,7 +1107,7 @@ static void _parseStakeCredential(read_view_t* view, stake_credential_t* stakeCr
 		break;
 	case STAKE_CREDENTIAL_SCRIPT_HASH: {
 		STATIC_ASSERT(SIZEOF(stakeCredential->scriptHash) == SCRIPT_HASH_LENGTH, "bad script hash container size");
-		VALIDATE(SIZEOF(stakeCredential->scriptHash) <= view_remainingSize(view), ERR_INVALID_DATA);
+		VALIDATE(view_remainingSize(view) >= SIZEOF(stakeCredential->scriptHash), ERR_INVALID_DATA);
 		view_memmove(stakeCredential->scriptHash, view, SIZEOF(stakeCredential->scriptHash));
 		break;
 	}
@@ -1122,19 +1124,16 @@ static void _parseCertificateData(uint8_t* wireDataBuffer, size_t wireDataSize, 
 
 	read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-	VALIDATE(view_remainingSize(&view) >= 1, ERR_INVALID_DATA);
 	certificateData->type = parse_u1be(&view);
 	TRACE("Certificate type: %d", certificateData->type);
 
 	switch (certificateData->type) {
 	case CERTIFICATE_TYPE_STAKE_REGISTRATION:
 		_parseStakeCredential(&view, &certificateData->stakeCredential);
-		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 		break;
 
 	case CERTIFICATE_TYPE_STAKE_DEREGISTRATION:
 		_parseStakeCredential(&view, &certificateData->stakeCredential);
-		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 		break;
 
 	case CERTIFICATE_TYPE_STAKE_DELEGATION:
@@ -1147,20 +1146,18 @@ static void _parseCertificateData(uint8_t* wireDataBuffer, size_t wireDataSize, 
 	case CERTIFICATE_TYPE_STAKE_POOL_REGISTRATION:
 		// nothing more to parse, certificate data will be provided
 		// in additional APDUs processed by a submachine
-		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 		return;
 
 	case CERTIFICATE_TYPE_STAKE_POOL_RETIREMENT:
 		_parsePathSpec(&view, &certificateData->poolIdPath);
-		VALIDATE(view_remainingSize(&view) == 8, ERR_INVALID_DATA);
-		certificateData->epoch  = parse_u8be(&view);
+		certificateData->epoch = parse_u8be(&view);
 		break;
 
 	default:
 		THROW(ERR_INVALID_DATA);
 	}
 
-	ASSERT(view_remainingSize(&view) == 0);
+	VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 }
 
 static void _fillHashFromPath(const bip44_path_t* path,
@@ -1464,7 +1461,6 @@ static void signTx_handleWithdrawalAPDU(uint8_t p2, uint8_t* wireDataBuffer, siz
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
-		VALIDATE(view_remainingSize(&view) >= 8, ERR_INVALID_DATA);
 		txBodyCtx->stageData.withdrawal.amount = parse_u8be(&view);
 
 		_parseStakeCredential(&view, &txBodyCtx->stageData.withdrawal.stakeCredential);

--- a/src/signTxCatalystRegistration.c
+++ b/src/signTxCatalystRegistration.c
@@ -138,11 +138,13 @@ static void signTxCatalystRegistration_handleVotingKeyAPDU(uint8_t* wireDataBuff
 	{
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 
-		STATIC_ASSERT(SIZEOF(subctx->stateData.votingPubKey) == CATALYST_VOTING_PUBLIC_KEY_LENGTH, "wrong voting public key size");
 		{
 			VALIDATE(wireDataSize == SIZEOF(subctx->stateData.votingPubKey), ERR_INVALID_DATA);
 			read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
-			view_memmove(subctx->stateData.votingPubKey, &view, CATALYST_VOTING_PUBLIC_KEY_LENGTH);
+
+			STATIC_ASSERT(SIZEOF(subctx->stateData.votingPubKey) == CATALYST_VOTING_PUBLIC_KEY_LENGTH, "wrong voting public key size");
+			view_copyWireToBuffer(subctx->stateData.votingPubKey, &view, CATALYST_VOTING_PUBLIC_KEY_LENGTH);
+
 			VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 		}
 	}

--- a/src/signTxMint.c
+++ b/src/signTxMint.c
@@ -75,7 +75,7 @@ static void signTxMint_handleTopLevelDataAPDU(uint8_t* wireDataBuffer, size_t wi
 	TRACE_BUFFER(wireDataBuffer, wireDataSize);
 	{
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
-		VALIDATE(view_remainingSize(&view) >= 4, ERR_INVALID_DATA);
+
 		uint32_t numAssetGroups = parse_u4be(&view);
 		TRACE("num asset groups %u", numAssetGroups);
 		VALIDATE(numAssetGroups <= OUTPUT_ASSET_GROUPS_MAX, ERR_INVALID_DATA);
@@ -136,13 +136,14 @@ static void signTxMint_handleAssetGroupAPDU(uint8_t* wireDataBuffer, size_t wire
 		STATIC_ASSERT(SIZEOF(tokenGroup->policyId) == MINTING_POLICY_ID_SIZE, "wrong policy id size");
 		view_memmove(tokenGroup->policyId, &view, MINTING_POLICY_ID_SIZE);
 
-		VALIDATE(view_remainingSize(&view) == 4, ERR_INVALID_DATA);
 		uint32_t numTokens = parse_u4be(&view);
 		VALIDATE(numTokens <= OUTPUT_TOKENS_IN_GROUP_MAX, ERR_INVALID_DATA);
 		VALIDATE(numTokens > 0, ERR_INVALID_DATA);
 		STATIC_ASSERT(OUTPUT_TOKENS_IN_GROUP_MAX <= UINT16_MAX, "wrong max token amounts in a group");
 		ASSERT_TYPE(subctx->numTokens, uint16_t);
 		subctx->numTokens = (uint16_t) numTokens;
+
+		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 	}
 
 	{
@@ -217,16 +218,16 @@ static void signTxMint_handleTokenAPDU(uint8_t* wireDataBuffer, size_t wireDataS
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-		VALIDATE(view_remainingSize(&view) >= 4, ERR_INVALID_DATA);
 		token->assetNameSize = parse_u4be(&view);
 		VALIDATE(token->assetNameSize <= ASSET_NAME_SIZE_MAX, ERR_INVALID_DATA);
 
 		ASSERT(token->assetNameSize <= SIZEOF(token->assetNameBytes));
 		view_memmove(token->assetNameBytes, &view, token->assetNameSize);
 
-		VALIDATE(view_remainingSize(&view) == 8, ERR_INVALID_DATA);
 		token->amount = parse_int64be(&view);
 		TRACE_INT64(token->amount);
+
+		VALIDATE(view_remainingSize(&view) == 0, ERR_INVALID_DATA);
 	}
 
 	{

--- a/src/signTxMint.c
+++ b/src/signTxMint.c
@@ -132,9 +132,8 @@ static void signTxMint_handleAssetGroupAPDU(uint8_t* wireDataBuffer, size_t wire
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-		VALIDATE(view_remainingSize(&view) >= MINTING_POLICY_ID_SIZE, ERR_INVALID_DATA);
 		STATIC_ASSERT(SIZEOF(tokenGroup->policyId) == MINTING_POLICY_ID_SIZE, "wrong policy id size");
-		view_memmove(tokenGroup->policyId, &view, MINTING_POLICY_ID_SIZE);
+		view_copyWireToBuffer(tokenGroup->policyId, &view, MINTING_POLICY_ID_SIZE);
 
 		uint32_t numTokens = parse_u4be(&view);
 		VALIDATE(numTokens <= OUTPUT_TOKENS_IN_GROUP_MAX, ERR_INVALID_DATA);
@@ -222,7 +221,7 @@ static void signTxMint_handleTokenAPDU(uint8_t* wireDataBuffer, size_t wireDataS
 		VALIDATE(token->assetNameSize <= ASSET_NAME_SIZE_MAX, ERR_INVALID_DATA);
 
 		ASSERT(token->assetNameSize <= SIZEOF(token->assetNameBytes));
-		view_memmove(token->assetNameBytes, &view, token->assetNameSize);
+		view_copyWireToBuffer(token->assetNameBytes, &view, token->assetNameSize);
 
 		token->amount = parse_int64be(&view);
 		TRACE_INT64(token->amount);

--- a/src/signTxOutput.c
+++ b/src/signTxOutput.c
@@ -300,7 +300,7 @@ static void signTxOutput_handleTopLevelDataAPDU(uint8_t* wireDataBuffer, size_t 
 			TRACE("Address length %u", output->address.size);
 			VALIDATE(output->address.size <= MAX_ADDRESS_SIZE, ERR_INVALID_DATA);
 
-			ASSERT(SIZEOF(output->address.buffer) >= output->address.size);
+			STATIC_ASSERT(SIZEOF(output->address.buffer) >= MAX_ADDRESS_SIZE, "wrong address buffer size");
 			view_copyWireToBuffer(output->address.buffer, &view, output->address.size);
 			TRACE_BUFFER(output->address.buffer, output->address.size);
 			break;

--- a/src/signTxOutput.c
+++ b/src/signTxOutput.c
@@ -299,10 +299,9 @@ static void signTxOutput_handleTopLevelDataAPDU(uint8_t* wireDataBuffer, size_t 
 			output->address.size = parse_u4be(&view);
 			TRACE("Address length %u", output->address.size);
 			VALIDATE(output->address.size <= MAX_ADDRESS_SIZE, ERR_INVALID_DATA);
-			VALIDATE(view_remainingSize(&view) >= output->address.size, ERR_INVALID_DATA);
 
 			ASSERT(SIZEOF(output->address.buffer) >= output->address.size);
-			view_memmove(output->address.buffer, &view, output->address.size);
+			view_copyWireToBuffer(output->address.buffer, &view, output->address.size);
 			TRACE_BUFFER(output->address.buffer, output->address.size);
 			break;
 		}
@@ -387,9 +386,8 @@ static void signTxOutput_handleAssetGroupAPDU(uint8_t* wireDataBuffer, size_t wi
 		TRACE_BUFFER(wireDataBuffer, wireDataSize);
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-		VALIDATE(view_remainingSize(&view) >= MINTING_POLICY_ID_SIZE, ERR_INVALID_DATA);
 		STATIC_ASSERT(SIZEOF(tokenGroup->policyId) == MINTING_POLICY_ID_SIZE, "wrong policy id size");
-		view_memmove(tokenGroup->policyId, &view, MINTING_POLICY_ID_SIZE);
+		view_copyWireToBuffer(tokenGroup->policyId, &view, MINTING_POLICY_ID_SIZE);
 
 		uint32_t numTokens = parse_u4be(&view);
 		VALIDATE(numTokens <= OUTPUT_TOKENS_IN_GROUP_MAX, ERR_INVALID_DATA);
@@ -478,7 +476,7 @@ static void signTxOutput_handleTokenAPDU(uint8_t* wireDataBuffer, size_t wireDat
 		VALIDATE(token->assetNameSize <= ASSET_NAME_SIZE_MAX, ERR_INVALID_DATA);
 
 		ASSERT(token->assetNameSize <= SIZEOF(token->assetNameBytes));
-		view_memmove(token->assetNameBytes, &view, token->assetNameSize);
+		view_copyWireToBuffer(token->assetNameBytes, &view, token->assetNameSize);
 
 		token->amount = parse_u8be(&view);
 		TRACE_UINT64(token->amount);

--- a/src/signTxPoolRegistration.c
+++ b/src/signTxPoolRegistration.c
@@ -288,7 +288,6 @@ static void _parsePoolId(read_view_t* view)
 {
 	pool_id_t* key = &subctx->stateData.poolId;
 
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	key->keyReferenceType = parse_u1be(view);
 
 	switch (key->keyReferenceType) {
@@ -603,7 +602,6 @@ static void _parsePoolRewardAccount(read_view_t* view)
 {
 	reward_account_t* rewardAccount = &subctx->stateData.poolRewardAccount;
 
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	rewardAccount->keyReferenceType = parse_u1be(view);
 
 	switch (rewardAccount->keyReferenceType) {
@@ -779,7 +777,6 @@ static void signTxPoolRegistration_handleOwnerAPDU(uint8_t* wireDataBuffer, size
 
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-		VALIDATE(view_remainingSize(&view) >= 1, ERR_INVALID_DATA);
 		owner->keyReferenceType = parse_u1be(&view);
 		switch (owner->keyReferenceType) {
 
@@ -953,7 +950,6 @@ static void handleRelay_dns_ui_runStep()
 
 static void _parsePort(ipport_t* port, read_view_t* view)
 {
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	uint8_t isPortGiven = parse_u1be(view);
 	if (isPortGiven == ITEM_INCLUDED_YES) {
 		port->isNull = false;
@@ -968,7 +964,6 @@ static void _parsePort(ipport_t* port, read_view_t* view)
 
 static void _parseIpv4(ipv4_t* ipv4, read_view_t* view)
 {
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	uint8_t isIpv4Given = parse_u1be(view);
 	if (isIpv4Given == ITEM_INCLUDED_YES) {
 		ipv4->isNull = false;
@@ -985,7 +980,6 @@ static void _parseIpv4(ipv4_t* ipv4, read_view_t* view)
 
 static void _parseIpv6(ipv6_t* ipv6, read_view_t* view)
 {
-	VALIDATE(view_remainingSize(view) >= 1, ERR_INVALID_DATA);
 	uint8_t isIpv6Given = parse_u1be(view);
 	if (isIpv6Given == ITEM_INCLUDED_YES) {
 		ipv6->isNull = false;
@@ -1040,7 +1034,6 @@ static void signTxPoolRegistration_handleRelayAPDU(uint8_t* wireDataBuffer, size
 
 		read_view_t view = make_read_view(wireDataBuffer, wireDataBuffer + wireDataSize);
 
-		VALIDATE(view_remainingSize(&view) >= 1, ERR_INVALID_DATA);
 		relay->format = parse_u1be(&view);
 		TRACE("Relay format %u", relay->format);
 		switch (relay->format) {
@@ -1262,9 +1255,6 @@ static void signTxPoolRegistration_handlePoolMetadataAPDU(uint8_t* wireDataBuffe
 
 		{
 			// deal with null metadata
-
-			VALIDATE(view_remainingSize(&view) >= 1, ERR_INVALID_DATA);
-
 			uint8_t includeMetadataByte = parse_u1be(&view);
 			int includeMetadata = signTx_parseIncluded(includeMetadataByte);
 

--- a/src/signTxPoolRegistration.c
+++ b/src/signTxPoolRegistration.c
@@ -607,7 +607,7 @@ static void _parsePoolRewardAccount(read_view_t* view)
 	switch (rewardAccount->keyReferenceType) {
 
 	case KEY_REFERENCE_HASH: {
-		STATIC_ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account size");
+		STATIC_ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account hash buffer size");
 		view_copyWireToBuffer(rewardAccount->hashBuffer, view, REWARD_ACCOUNT_SIZE);
 		TRACE_BUFFER(rewardAccount->hashBuffer, SIZEOF(rewardAccount->hashBuffer));
 

--- a/src/textUtils.c
+++ b/src/textUtils.c
@@ -193,7 +193,7 @@ size_t str_formatValidityBoundary(uint64_t slotNumber, char* out, size_t outSize
 	uint64_t epoch = startEpoch + (slotNumber - startSlotNumber) / slotsInEpoch;
 	uint64_t slotInEpoch = (slotNumber - startSlotNumber) % slotsInEpoch;
 
-	ASSERT(sizeof(int) >= sizeof(uint32_t));
+	STATIC_ASSERT(sizeof(int) >= sizeof(uint32_t), "wrong int size");
 
 	ASSERT(outSize > 0); // so we can write null terminator
 	if (epoch > 1000000)  {

--- a/src/uiScreens.c
+++ b/src/uiScreens.c
@@ -411,7 +411,7 @@ void ui_displayStakingInfoScreen(
 	case STAKING_KEY_HASH: {
 		heading = STAKING_HEADING_KEY_HASH;
 		bech32_encode(
-		        "stake_vkh", // TODO what about stake_shared_vkh? we can't determine when it applies
+		        "stake_vkh", // shares keys never go into address directly
 		        addressParams->stakingKeyHash, SIZEOF(addressParams->stakingKeyHash),
 		        stakingInfo, SIZEOF(stakingInfo)
 		);

--- a/src/uiScreens.c
+++ b/src/uiScreens.c
@@ -303,8 +303,8 @@ void ui_displayRewardAccountScreen(
 		        "Reward account"
 		);
 
-		ASSERT(SIZEOF(rewardAccountBuffer) == REWARD_ACCOUNT_SIZE);
-		ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE);
+		STATIC_ASSERT(SIZEOF(rewardAccountBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account buffer size");
+		STATIC_ASSERT(SIZEOF(rewardAccount->hashBuffer) == REWARD_ACCOUNT_SIZE, "wrong reward account hash buffer size");
 		memmove(rewardAccountBuffer, rewardAccount->hashBuffer, REWARD_ACCOUNT_SIZE);
 		break;
 	}
@@ -666,7 +666,7 @@ void ui_displayPoolOwnerScreen(
 			break;
 		}
 		case KEY_REFERENCE_HASH: {
-			ASSERT(SIZEOF(owner->keyHash) == ADDRESS_KEY_HASH_LENGTH);
+			STATIC_ASSERT(SIZEOF(owner->keyHash) == ADDRESS_KEY_HASH_LENGTH, "wrong owner.keyHash size");
 
 			constructRewardAddressFromHash(
 			        networkId, REWARD_HASH_SOURCE_KEY,


### PR DESCRIPTION
Resolves #90 .

It seems we have no more problems with bech32, hex buffer screen is used where it should, and bech32 prefixes seem correct (keys are almost always displayed as paths).