### PR TITLE
implement single account mode

### DIFF
--- a/src/signTx.h
+++ b/src/signTx.h
@@ -50,11 +50,19 @@ enum {
 };
 
 typedef struct {
+	bool isStored;
+	bool isByron;
+	uint32_t accountNumber;
+} single_account_data_t;
+
+typedef struct {
 	// significantly affects restrictions on the tx
 	sign_tx_signingmode_t txSigningMode;
 
 	uint8_t networkId; // part of Shelley address
 	uint32_t protocolMagic; // part of Byron address
+
+	single_account_data_t singleAccountData;
 } common_tx_data_t;
 
 typedef struct {

--- a/src/signTxUtils.c
+++ b/src/signTxUtils.c
@@ -3,10 +3,40 @@
 #include "uiHelpers.h"
 #include "utils.h"
 #include "signTxUtils.h"
+#include "securityPolicy.h"
+#include "state.h"
 
 void respondSuccessEmptyMsg()
 {
 	TRACE();
 	io_send_buf(SUCCESS, NULL, 0);
 	ui_displayBusy(); // needs to happen after I/O
+}
+
+bool violatesSingleAccountOrStoreIt(const bip44_path_t* path)
+{
+	single_account_data_t* singleAccountData = &(instructionState.signTxContext.commonTxData.singleAccountData);
+
+	if (!bip44_hasOrdinaryWalletKeyPrefix(path) || !bip44_containsAccount(path)) {
+		TRACE("Invalid path in single account check");
+		ASSERT(false);
+	}
+	const bool isByron = bip44_hasByronPrefix(path);
+	const uint32_t account = bip44_getAccount(path);
+	if (singleAccountData->isStored) {
+		const uint32_t storedAccount = singleAccountData->accountNumber;
+		if (account != storedAccount) {
+			return true;
+		}
+		const bool combinesByronAndShelley = singleAccountData->isByron != isByron;
+		const bool combinationAllowed = (storedAccount == 0);
+		if (combinesByronAndShelley && !combinationAllowed) {
+			return true;
+		}
+	} else {
+		singleAccountData->isStored = true;
+		singleAccountData->isByron = isByron;
+		singleAccountData->accountNumber = account;
+	}
+	return false;
 }

--- a/src/signTxUtils.h
+++ b/src/signTxUtils.h
@@ -1,6 +1,18 @@
 #ifndef H_CARDANO_APP_SIGN_TX_UTILS
 #define H_CARDANO_APP_SIGN_TX_UTILS
 
+#include "bip44.h"
+
 void respondSuccessEmptyMsg();
+
+/**
+ * Checks if the path has the same account as the already stored one
+ * with regard to Byron and Shelley equivalency at account number 0
+ *
+ * If it is the first path and it fits the criteria, it stores it instead
+ *
+ * Criteria: path has an ordinary Shelley or Byron prefix and has at least account
+ */
+bool violatesSingleAccountOrStoreIt(const bip44_path_t* path);
 
 #endif  // H_CARDANO_APP_SIGN_TX_UTILS


### PR DESCRIPTION
Should checks be included with the security policies?
Are the Byron-Shelley check correct?
Should we spare a bunch of bytes by compressing down the stored data to just three pieces (<is it byron>, <account number>, <is it stored>)? 