### PR TITLE
UI output correction for pool retirement

### DIFF
--- a/src/signTx.c
+++ b/src/signTx.c
@@ -1045,7 +1045,7 @@ static void signTx_handleCertificatePoolRetirement_ui_runStep()
 	}
 	UI_STEP(HANDLE_CERTIFICATE_POOL_RETIREMENT_STEP_DISPLAY_EPOCH) {
 		ui_displayUint64Screen(
-		        "at the begin of epoch",
+		        "at the start of epoch",
 		        BODY_CTX->stageData.certificate.epoch,
 		        this_fn
 		);

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -4,7 +4,7 @@
 #include "cardano.h"
 #include "addressUtilsByron.h"
 #include "addressUtilsShelley.h"
-#include "uiHelpers.h"
+#include "uiHelpers.h"e
 #include "signTxUtils.h"
 #include "uiScreens.h"
 #include "txHashBuilder.h"
@@ -1045,7 +1045,7 @@ static void signTx_handleCertificatePoolRetirement_ui_runStep()
 	}
 	UI_STEP(HANDLE_CERTIFICATE_POOL_RETIREMENT_STEP_DISPLAY_EPOCH) {
 		ui_displayUint64Screen(
-		        "at the end of epoch",
+		        "at the begin of epoch",
 		        BODY_CTX->stageData.certificate.epoch,
 		        this_fn
 		);

--- a/src/signTx.c
+++ b/src/signTx.c
@@ -4,7 +4,7 @@
 #include "cardano.h"
 #include "addressUtilsByron.h"
 #include "addressUtilsShelley.h"
-#include "uiHelpers.h"e
+#include "uiHelpers.h"
 #include "signTxUtils.h"
 #include "uiScreens.h"
 #include "txHashBuilder.h"


### PR DESCRIPTION
The UI is showing "... retirement at the **end** of epoch xxx" for confirmation. Actually the retirement is at the **begin** of the retirement epoch, not at the end. Text still fits into the Nano S display. word could also be changed into start. Just a minor fix.